### PR TITLE
Date parse text validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devextreme-intl",
   "description": "Integrates ECMAScript Internationalization API with DevExtreme",
-  "version": "17.1.4-pre-17130",
+  "version": "17.1.4",
   "author": "Developer Express Inc.",
   "license": "MIT",
   "repository": {

--- a/src/date.js
+++ b/src/date.js
@@ -106,7 +106,7 @@ dateLocalization.inject({
 
     parse: function(dateString, format) {
         var SIMPLE_FORMATS = ['shortdate', 'shorttime', 'shortdateshorttime', 'longtime'];
-        if(typeof format === 'string' && SIMPLE_FORMATS.indexOf(format.toLowerCase()) > -1) {
+        if(dateString && typeof format === 'string' && SIMPLE_FORMATS.indexOf(format.toLowerCase()) > -1) {
             return this._parseDateBySimpleFormat(dateString, format.toLowerCase());
         }
 

--- a/tests/date-tests.js
+++ b/tests/date-tests.js
@@ -235,6 +235,12 @@ require('../src/date');
         });
     });
 
+    QUnit.test('parse wrong arguments', function(assert) {
+        assert.equal(dateLocalization.parse(null, 'shortDate'), undefined);
+        assert.equal(dateLocalization.parse(undefined, 'shortDate'), undefined);
+        assert.equal(dateLocalization.parse('', 'shortDate'), undefined);
+    });
+
     QUnit.test('DevExtreme format uses default locale options', function(assert) {
         var date = new Date();
 

--- a/tests/number-tests.js
+++ b/tests/number-tests.js
@@ -103,17 +103,17 @@ require('../src/number');
             {
                 value: 12345.67,
                 format: { type: 'currency largeNumber', precision: 2 },
-                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 2 })(12.34567) + 'K'
+                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 2 })(12.34567).replace(/(\d|.$)(\D*)$/, '$1K$2')
             },
             {
                 value: 12345.67,
                 format: { type: 'currency thousands', precision: 2 },
-                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 2 })(12.34567) + 'K'
+                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 2 })(12.34567).replace(/(\d|.$)(\D*)$/, '$1K$2')
             },
             {
                 value: 12345.67,
                 format: { type: 'currency millions', precision: 3 },
-                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 3 })(0.012) + 'M'
+                expected: getIntlFormatter({style: 'currency', currency: 'USD', minimumFractionDigits: 3 })(0.012).replace(/(\d|.$)(\D*)$/, '$1M$2')
             }
         ];
 


### PR DESCRIPTION
Fix for the issue [T536130](https://www.devexpress.com/Support/Center/Question/Details/T536130/the-cannot-read-property-split-of-null-error-occurs-when-focusing-out-from-an-empty)