### PR TITLE
Implement a workaround for the MS Edge and IE bug

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -61,11 +61,9 @@ var normalizeMonth = function(text) {
 var intlFormats = {
     day: { day: 'numeric' },
     dayofweek: { weekday: 'long' },
-    hour: { hour: 'numeric', hour12: false },
     longdate: { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' },
     longdatelongtime: { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric' },
     longtime: { hour: 'numeric', minute: 'numeric', second: 'numeric' },
-    minute: { minute: 'numeric' },
     month: { month: 'long' },
     monthandday: { month: 'long', day: 'numeric' },
     monthandyear: { year: 'numeric', month: 'long' },


### PR DESCRIPTION
Fix for the issue [T567719](https://www.devexpress.com/Support/Center/Question/Details/T567719/dxdatebox-shows-a-date-in-a-wrong-format-in-ie-if-pickertype-is-set-to-rollers).