### PR TITLE
Format date in UTC timezone

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -176,7 +176,11 @@ dateLocalization.inject({
 
         var intlFormat = getIntlFormat(format);
         if(intlFormat) {
-            return getIntlFormatter(intlFormat)(date);
+            // Workaround for https://github.com/andyearnshaw/Intl.js/issues/304
+            var utcDate = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
+            intlFormat.timeZone = 'UTC';
+
+            return getIntlFormatter(intlFormat)(utcDate);
         }
 
         var formatType = typeof format;

--- a/src/date.js
+++ b/src/date.js
@@ -175,11 +175,14 @@ dateLocalization.inject({
         format = format.type || format;
 
         var intlFormat = getIntlFormat(format);
-        if(intlFormat) {
-            // Workaround for https://github.com/andyearnshaw/Intl.js/issues/304
-            var utcDate = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
-            intlFormat.timeZone = 'UTC';
 
+        // There are differences between date formatting in different browsers. All browsers create date by 'new Date()'
+        // with current timezone offset for all date. Chrome and Firefox format this date with an offset for the created date,
+        // but IE and Edge use the current offset.
+        var utcDate = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), date.getHours(), date.getMinutes(), date.getSeconds());
+
+        if(intlFormat) {
+            intlFormat.timeZone = 'UTC';
             return getIntlFormatter(intlFormat)(utcDate);
         }
 
@@ -188,7 +191,12 @@ dateLocalization.inject({
             return this.callBase.apply(this, arguments);
         }
 
-        return getIntlFormatter(format)(date);
+        if(format.timeZoneName) {
+            return getIntlFormatter(format)(date);
+        } else {
+            format.timeZone = 'UTC';
+            return getIntlFormatter(format)(utcDate);
+        }
     },
 
     parse: function(dateString, format) {


### PR DESCRIPTION
Fix [T604782](https://www.devexpress.com/Support/Center/Question/Details/T604782/datebox-shows-some-month-names-incorrectly-when-istanbul-time-zone-is-used)

Intl in some browsers formates dates with timezone offset which was at the moment for this date. But the method "new Date" creates date using current offset. So, we decided to format dates in the UTC timezone.

For example in Russian timezone:
new Intl.DateTimeFormat('ru', { hour: 'numeric', minute: 'numeric' }).format(new Date(2010, 2, 28, 3))
Chrome, Firefox - '4:00'
IE, Edge - '3:00'