### PR TITLE
Don't display deprecation warning in ASP.NET + Globalize environment

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -4,6 +4,7 @@ var dateLocalization = require('devextreme/localization').date;
 var firstDayOfWeekData = require('../locale-data/first-day-of-week-data');
 var dxVersion = require('devextreme/core/version');
 var compareVersions = require('devextreme/core/utils/version').compare;
+var deprecationWarning = require('./deprecation-warning');
 
 var SYMBOLS_TO_REMOVE_REGEX = /[\u200E\u200F]/g;
 
@@ -335,8 +336,7 @@ var intlIsEmbedded = compareVersions(dxVersion, '19.2.1') > -1;
 var intlIsActive = dateLocalization.engine && dateLocalization.engine() === 'intl';
 
 if(intlIsEmbedded) {
-    // eslint-disable-next-line no-console
-    console.log('Since v19.2, Intl localization utilities are included in DevExtreme. Do not use the separate devextreme-intl module.');
+    deprecationWarning();
 }
 
 if(!intlIsEmbedded || !intlIsActive) {

--- a/src/deprecation-warning.js
+++ b/src/deprecation-warning.js
@@ -1,0 +1,16 @@
+var displayed = false;
+
+function isAspNetCompatMode() {
+    var globalDevExpress = window.DevExpress;
+    return Boolean(globalDevExpress && globalDevExpress.aspnet && window.Globalize);
+}
+
+module.exports = function() {
+    if(!displayed) {
+        if(!isAspNetCompatMode()) {
+            // eslint-disable-next-line no-console
+            console.log('Since v19.2, Intl localization utilities are included in DevExtreme. Do not use the separate devextreme-intl module.');
+        }
+        displayed = true;
+    }
+};

--- a/src/number.js
+++ b/src/number.js
@@ -4,6 +4,7 @@ var locale = require('devextreme/localization').locale;
 var numberLocalization = require('devextreme/localization').number;
 var dxVersion = require('devextreme/core/version');
 var compareVersions = require('devextreme/core/utils/version').compare;
+var deprecationWarning = require('./deprecation-warning');
 
 var currencyOptionsCache = {},
     detectCurrencySymbolRegex = /([^\s0]+)?(\s*)0*[.,]*0*(\s*)([^\s0]+)?/,
@@ -194,8 +195,7 @@ var intlIsEmbedded = compareVersions(dxVersion, '19.2.1') > -1;
 var intlIsActive = numberLocalization.engine && numberLocalization.engine() === 'intl';
 
 if(intlIsEmbedded) {
-    // eslint-disable-next-line no-console
-    console.log('Since v19.2, Intl localization utilities are included in DevExtreme. Do not use the separate devextreme-intl module.');
+    deprecationWarning();
 }
 
 if(!intlIsEmbedded || !intlIsActive) {    


### PR DESCRIPTION
We didn't have time to update ASP.NET demos, project templates, and docs for the [T817510 BC](https://devexpress.com/issue=T817510). They are still Globalize-first and require `devextreme-intl.js` to be included.

I suggest that we hide the warning when Globalize and dx.aspnet.mvc.js scripts are detected.

FYI @MargaritaLoseva 